### PR TITLE
[General fix] Passing static analysis

### DIFF
--- a/include/nmealib/nmea0183.hpp
+++ b/include/nmealib/nmea0183.hpp
@@ -215,7 +215,7 @@ public:
      * @return true If there is no checksum or if the checksum matches the calculated checksum for the payload
      * @return false If there is a checksum and it does not match the calculated checksum for the payload
      */
-    bool validate() const override;
+    bool validate() const noexcept override;
 
     /**
      * @brief Converts an NMEA coordinate in ddmm.mmmm / dddmm.mmmm format to decimal degrees.
@@ -245,7 +245,7 @@ protected:
      * @throws TooLongSentenceException If the input string exceeds the maximum allowed length of 82 characters.
      * @throws InvalidStartCharacterException If the input string does not start with either '$' or '!'.
      */
-    static std::unique_ptr<Message0183> create(std::string raw, TimePoint ts = std::chrono::system_clock::now());
+    static std::unique_ptr<Message0183> create(const std::string& raw, TimePoint ts = std::chrono::system_clock::now());
 
 private:
     explicit Message0183(std::string raw,

--- a/include/nmealib/nmea0183/dbt.hpp
+++ b/include/nmealib/nmea0183/dbt.hpp
@@ -43,12 +43,12 @@ public:
     bool hasEqualContent(const DBT& other) const noexcept;
 
 private:
-    double depthFeet_;
-    char feetUnit_;
-    double depthMeters_;
-    char metersUnit_;
-    double depthFathoms_;
-    char fathomsUnit_;
+    double depthFeet_{};
+    char feetUnit_{};
+    double depthMeters_{};
+    char metersUnit_{};
+    double depthFathoms_{};
+    char fathomsUnit_{};
 
     DBT() = default;
 
@@ -62,7 +62,7 @@ private:
     ) noexcept;
 
     static std::unique_ptr<DBT> create(std::unique_ptr<Message0183> baseMessage);
-    static std::string composeRaw(std::string talkerId,
+    static std::string composeRaw(const std::string& talkerId,
                                   double depthFeet,
                                   char feetUnit,
                                   double depthMeters,

--- a/include/nmealib/nmea0183/gga.hpp
+++ b/include/nmealib/nmea0183/gga.hpp
@@ -44,7 +44,7 @@ public:
     std::unique_ptr<nmealib::Message> clone() const override;
 
     // GGA-specific getters
-    double getTimestamp() const noexcept;
+    double getUtcTime() const noexcept;
     double getLatitude() const noexcept;
     char getLatitudeDirection() const noexcept;
     double getLongitude() const noexcept;
@@ -66,20 +66,20 @@ public:
     bool hasEqualContent(const GGA& other) const noexcept;
 
 private:
-    double timestamp_;
-    double latitude_;
-    char latitudeDirection_;
-    double longitude_;
-    char longitudeDirection_;
-    unsigned int gpsQuality_;
-    unsigned int satellites_;
-    double hdop_;
-    double altitude_;
-    char altitudeUnits_;
-    double geoidalSeparation_;
-    char geoidalSeparationUnits_;
-    double dgpsAge_;
-    std::string dgpsReferenceStationId_;
+    double utcTime_{};
+    double latitude_{};
+    char latitudeDirection_{};
+    double longitude_{};
+    char longitudeDirection_{};
+    unsigned int gpsQuality_{};
+    unsigned int satellites_{};
+    double hdop_{};
+    double altitude_{};
+    char altitudeUnits_{};
+    double geoidalSeparation_{};
+    char geoidalSeparationUnits_{};
+    double dgpsAge_{};
+    std::string dgpsReferenceStationId_{};
 
     GGA() = default;
 
@@ -103,7 +103,7 @@ private:
 
     // Private internal factory
     static std::unique_ptr<GGA> create(std::unique_ptr<Message0183> baseMessage);
-    static std::string composeRaw(std::string talkerId,
+    static std::string composeRaw(const std::string& talkerId,
                                   double timestamp,
                                   double latitude,
                                   char latitudeDirection,
@@ -117,7 +117,7 @@ private:
                                   double geoidalSeparation,
                                   char geoidalSeparationUnits,
                                   double dgpsAge,
-                                  std::string dgpsReferenceStationId);
+                                  const std::string& dgpsReferenceStationId);
 
     friend class Nmea0183Factory;
     friend class MessageRegistry;

--- a/include/nmealib/nmea0183/gll.hpp
+++ b/include/nmealib/nmea0183/gll.hpp
@@ -41,7 +41,7 @@ public:
     char getLatitudeDirection() const noexcept;
     double getLongitude() const noexcept;
     char getLongitudeDirection() const noexcept;
-    double getTimestamp() const noexcept;
+    double getUtcTime() const noexcept;
     char getStatus() const noexcept;
     char getModeIndicator() const noexcept;
 
@@ -51,13 +51,13 @@ public:
     bool hasEqualContent(const GLL& other) const noexcept;
 
 private:
-    double latitude_;
-    char latitudeDirection_;
-    double longitude_;
-    char longitudeDirection_;
-    double timestamp_;
-    char status_;
-    char modeIndicator_;
+    double latitude_{};
+    char latitudeDirection_{};
+    double longitude_{};
+    char longitudeDirection_{};
+    double utcTime_{};
+    char status_{};
+    char modeIndicator_{};
 
     GLL() = default;
 
@@ -74,7 +74,7 @@ private:
 
     // Private internal factory
     static std::unique_ptr<GLL> create(std::unique_ptr<Message0183> baseMessage);
-    static std::string composeRaw(std::string talkerId,
+    static std::string composeRaw(const std::string& talkerId,
                                   double latitude,
                                   char latitudeDirection,
                                   double longitude,

--- a/include/nmealib/nmea0183/gsa.hpp
+++ b/include/nmealib/nmea0183/gsa.hpp
@@ -50,13 +50,13 @@ public:
     bool hasEqualContent(const GSA& other) const noexcept;
 
 private:
-    char selectionMode_;
-    unsigned int mode_;
-    std::array<unsigned int, 12> satelliteIds_;
-    double pdop_;
-    double hdop_;
-    double vdop_;
-    std::optional<unsigned int> systemId_;
+    char selectionMode_{};
+    unsigned int mode_{};
+    std::array<unsigned int, 12> satelliteIds_{};
+    double pdop_{};
+    double hdop_{};
+    double vdop_{};
+    std::optional<unsigned int> systemId_{};
 
     GSA() = default;
 
@@ -71,7 +71,7 @@ private:
     ) noexcept;
 
     static std::unique_ptr<GSA> create(std::unique_ptr<Message0183> baseMessage);
-    static std::string composeRaw(std::string talkerId,
+    static std::string composeRaw(const std::string& talkerId,
                                   char selectionMode,
                                   unsigned int mode,
                                   std::array<unsigned int, 12> satelliteIds,

--- a/include/nmealib/nmea0183/mwv.hpp
+++ b/include/nmealib/nmea0183/mwv.hpp
@@ -41,11 +41,11 @@ public:
     bool hasEqualContent(const MWV& other) const noexcept;
 
 private:
-    double windAngle_;
-    char reference_;
-    double windSpeed_;
-    char windSpeedUnits_;
-    char status_;
+    double windAngle_{};
+    char reference_{};
+    double windSpeed_{};
+    char windSpeedUnits_{};
+    char status_{};
 
     MWV() = default;
 
@@ -58,7 +58,7 @@ private:
     ) noexcept;
 
     static std::unique_ptr<MWV> create(std::unique_ptr<Message0183> baseMessage);
-    static std::string composeRaw(std::string talkerId,
+    static std::string composeRaw(const std::string& talkerId,
                                   double windAngle,
                                   char reference,
                                   double windSpeed,

--- a/include/nmealib/nmea0183/rmc.hpp
+++ b/include/nmealib/nmea0183/rmc.hpp
@@ -82,19 +82,19 @@ public:
     bool hasEqualContent(const RMC& other) const noexcept;
 
 private:
-    unsigned int utcFix_;
-    char status_;
-    double latitude_;
-    char latitudeDirection_;
-    double longitude_;
-    char longitudeDirection_;
-    double speedOverGround_;
-    double courseOverGround_;
-    unsigned int date_;
-    double magneticVariation_;
-    char magneticVariationDirection_;
-    char modeIndicator_;
-    char navigationStatus_;
+    unsigned int utcFix_{};
+    char status_{};
+    double latitude_{};
+    char latitudeDirection_{};
+    double longitude_{};
+    char longitudeDirection_{};
+    double speedOverGround_{};
+    double courseOverGround_{};
+    unsigned int date_{};
+    double magneticVariation_{};
+    char magneticVariationDirection_{};
+    char modeIndicator_{};
+    char navigationStatus_{};
 
     RMC() = default;
 
@@ -117,7 +117,7 @@ private:
 
     // Private internal factory
     static std::unique_ptr<RMC> create(std::unique_ptr<Message0183> baseMessage);
-    static std::string composeRaw(std::string talkerId, unsigned int utcFix, 
+    static std::string composeRaw(const std::string& talkerId, unsigned int utcFix, 
                             char status, 
                             double latitude,
                             char latitudeDirection, 

--- a/include/nmealib/nmea0183/vtg.hpp
+++ b/include/nmealib/nmea0183/vtg.hpp
@@ -50,16 +50,16 @@ public:
     bool hasEqualContent(const VTG& other) const noexcept;
 
 private:
-    double courseOverGroundTrue_;
-    char courseOverGroundTrueType_;
-    double courseOverGroundMagnetic_;
-    char courseOverGroundMagneticType_;
-    double speedOverGroundKnots_;
-    char speedOverGroundKnotsType_;
-    double speedOverGroundKph_;
-    char speedOverGroundKphType_;
-    std::optional<char> faaModeIndicator_;
-    bool legacyFormat_;
+    double courseOverGroundTrue_{};
+    char courseOverGroundTrueType_{};
+    double courseOverGroundMagnetic_{};
+    char courseOverGroundMagneticType_{};
+    double speedOverGroundKnots_{};
+    char speedOverGroundKnotsType_{};
+    double speedOverGroundKph_{};
+    char speedOverGroundKphType_{};
+    std::optional<char> faaModeIndicator_{};
+    bool legacyFormat_{};
 
     VTG() = default;
 
@@ -77,7 +77,7 @@ private:
     ) noexcept;
 
     static std::unique_ptr<VTG> create(std::unique_ptr<Message0183> baseMessage);
-    static std::string composeRaw(std::string talkerId,
+    static std::string composeRaw(const std::string& talkerId,
                                   double courseOverGroundTrue,
                                   double courseOverGroundMagnetic,
                                   double speedOverGroundKnots,

--- a/include/nmealib/nmea0183/zda.hpp
+++ b/include/nmealib/nmea0183/zda.hpp
@@ -43,12 +43,12 @@ public:
     bool hasEqualContent(const ZDA& other) const noexcept;
 
 private:
-    double utcTime_;
-    unsigned int day_;
-    unsigned int month_;
-    unsigned int year_;
-    int localZoneHours_;
-    int localZoneMinutes_;
+    double utcTime_{};
+    unsigned int day_{};
+    unsigned int month_{};
+    unsigned int year_{};
+    int localZoneHours_{};
+    int localZoneMinutes_{};
 
     ZDA() = default;
 
@@ -62,7 +62,7 @@ private:
     ) noexcept;
 
     static std::unique_ptr<ZDA> create(std::unique_ptr<Message0183> baseMessage);
-    static std::string composeRaw(std::string talkerId,
+    static std::string composeRaw(const std::string& talkerId,
                                   double utcTime,
                                   unsigned int day,
                                   unsigned int month,

--- a/src/nmea0183.cpp
+++ b/src/nmea0183.cpp
@@ -41,7 +41,7 @@ Message0183::Message0183(std::string raw,
     calculatedChecksumStr_ = computeChecksum(payload_);
 }
 
-std::unique_ptr<Message0183> Message0183::create(std::string raw, TimePoint ts) {
+std::unique_ptr<Message0183> Message0183::create(const std::string& raw, TimePoint ts) {
     std::string context = "Message0183::create";
     validateFormat(context, raw);
 
@@ -147,11 +147,17 @@ std::string Message0183::serialize() const {
     return rawData_;
 }
 
-bool Message0183::validate() const {
-    if (checksumStr_.empty()) {
-        return true; // No checksum means we consider it valid by default
+bool Message0183::validate() const noexcept{
+    bool hasChecksum = true;
+    bool valid = true;
+    // Try to get checksum, if i get an exception it does not have one
+    try {
+        valid = getChecksumStr() == getCalculatedChecksumStr();
+    } catch (const NoChecksumException&) {
+        hasChecksum = false;
     }
-    return getChecksumStr() == getCalculatedChecksumStr();
+    
+    return !hasChecksum || valid;
 }
 
 std::string Message0183::computeChecksum(const std::string& payload) noexcept {

--- a/src/nmea0183/dbt.cpp
+++ b/src/nmea0183/dbt.cpp
@@ -123,7 +123,7 @@ std::string DBT::getStringContent(bool verbose) const noexcept {
     return ss.str();
 }
 
-std::string DBT::composeRaw(std::string talkerId,
+std::string DBT::composeRaw(const std::string& talkerId,
                              double depthFeet,
                              char feetUnit,
                              double depthMeters,

--- a/src/nmea0183/gga.cpp
+++ b/src/nmea0183/gga.cpp
@@ -90,7 +90,7 @@ GGA::GGA(Message0183 baseMessage,
          double dgpsAge,
          std::string dgpsReferenceStationId) noexcept
     : Message0183(std::move(baseMessage)),
-      timestamp_(timestamp),
+            utcTime_(timestamp),
       latitude_(latitude),
       latitudeDirection_(latitudeDirection),
       longitude_(longitude),
@@ -135,7 +135,7 @@ GGA::GGA(std::string talkerId,
                                                   geoidalSeparationUnits,
                                                   dgpsAge,
                                                   dgpsReferenceStationId))),
-      timestamp_(timestamp),
+                    utcTime_(timestamp),
       latitude_(latitude),
       latitudeDirection_(latitudeDirection),
       longitude_(longitude),
@@ -175,7 +175,7 @@ std::string GGA::getStringContent(bool verbose) const noexcept {
         ss << "Sentence Type: " << getSentenceType() << "\n";
         ss << "Checksum: " << (checksumStr_.empty() ? "None" : validity) << "\n";
         ss << "Fields:\n";
-        ss << "\tTimestamp: " << timestamp_ << "\n";
+        ss << "\tTimestamp: " << utcTime_ << "\n";
         ss << "\tLatitude: " << latitudeStr << "\n";
         ss << "\tLatitude Direction: " << latitudeDirection_ << "\n";
         ss << "\tLongitude: " << longitudeStr << "\n";
@@ -191,7 +191,7 @@ std::string GGA::getStringContent(bool verbose) const noexcept {
         ss << "\tDGPS Ref: " << dgpsReferenceStationId_;
     } else {
         ss << "[" << validity << "] " << typeToString(type_) << " " << getTalker() << " " << getSentenceType() << ": "
-           << "Time=" << timestamp_
+              << "Time=" << utcTime_
               << ", Lat=" << latitudeStr << latitudeDirection_
               << ", Lon=" << longitudeStr << longitudeDirection_
            << ", Qual=" << gpsQuality_
@@ -205,7 +205,7 @@ std::string GGA::getStringContent(bool verbose) const noexcept {
     return ss.str();
 }
 
-std::string GGA::composeRaw(std::string talkerId,
+std::string GGA::composeRaw(const std::string& talkerId,
                             double timestamp,
                             double latitude,
                             char latitudeDirection,
@@ -219,7 +219,7 @@ std::string GGA::composeRaw(std::string talkerId,
                             double geoidalSeparation,
                             char geoidalSeparationUnits,
                             double dgpsAge,
-                            std::string dgpsReferenceStationId) {
+                            const std::string& dgpsReferenceStationId) {
     std::ostringstream payloadStream;
     payloadStream << talkerId << "GGA,";
     payloadStream << std::fixed << std::setprecision(2) << std::setw(9) << std::setfill('0') << timestamp << ",";
@@ -262,8 +262,8 @@ std::string GGA::composeRaw(std::string talkerId,
     return "$" + payload + "\r\n";
 }
 
-double GGA::getTimestamp() const noexcept {
-    return timestamp_;
+double GGA::getUtcTime() const noexcept {
+    return utcTime_;
 }
 
 double GGA::getLatitude() const noexcept {

--- a/src/nmea0183/gll.cpp
+++ b/src/nmea0183/gll.cpp
@@ -72,7 +72,7 @@ GLL::GLL(Message0183 baseMessage,
       latitudeDirection_(latitudeDirection),
       longitude_(longitude),
       longitudeDirection_(longitudeDirection),
-      timestamp_(timestamp),
+            utcTime_(timestamp),
       status_(status),
       modeIndicator_(modeIndicator) {}
 
@@ -96,7 +96,7 @@ GLL::GLL(std::string talkerId,
       latitudeDirection_(latitudeDirection),
       longitude_(longitude),
       longitudeDirection_(longitudeDirection),
-      timestamp_(timestamp),
+    utcTime_(timestamp),
       status_(status),
       modeIndicator_(modeIndicator) {}
 
@@ -129,21 +129,21 @@ std::string GLL::getStringContent(bool verbose) const noexcept {
         ss << "\tLatitude Direction: " << latitudeDirection_ << "\n";
         ss << "\tLongitude: " << longitudeStr << "\n";
         ss << "\tLongitude Direction: " << longitudeDirection_ << "\n";
-        ss << "\tTimestamp: " << timestamp_ << "\n";
+        ss << "\tTimestamp: " << utcTime_ << "\n";
         ss << "\tStatus: " << status_ << "\n";
         ss << "\tMode Indicator: " << modeIndicator_;
     } else {
         ss << "[" << validity << "] " << typeToString(type_) << " " << getTalker() << " " << getSentenceType() << ": "
               << "Lat=" << latitudeStr << latitudeDirection_
               << ", Lon=" << longitudeStr << longitudeDirection_
-           << ", Time=" << timestamp_
+           << ", Time=" << utcTime_
            << ", Status=" << status_
            << ", Mode=" << modeIndicator_;
     }
     return ss.str();
 }
 
-std::string GLL::composeRaw(std::string talkerId,
+std::string GLL::composeRaw(const std::string& talkerId,
                             double latitude,
                             char latitudeDirection,
                             double longitude,
@@ -190,8 +190,8 @@ char GLL::getLongitudeDirection() const noexcept {
     return longitudeDirection_;
 }
 
-double GLL::getTimestamp() const noexcept {
-    return timestamp_;
+double GLL::getUtcTime() const noexcept {
+    return utcTime_;
 }
 
 char GLL::getStatus() const noexcept {

--- a/src/nmea0183/gsa.cpp
+++ b/src/nmea0183/gsa.cpp
@@ -168,7 +168,7 @@ std::string GSA::getStringContent(bool verbose) const noexcept {
     return ss.str();
 }
 
-std::string GSA::composeRaw(std::string talkerId,
+std::string GSA::composeRaw(const std::string& talkerId,
                             char selectionMode,
                             unsigned int mode,
                             std::array<unsigned int, 12> satelliteIds,

--- a/src/nmea0183/mwv.cpp
+++ b/src/nmea0183/mwv.cpp
@@ -116,7 +116,7 @@ std::string MWV::getStringContent(bool verbose) const noexcept {
     return ss.str();
 }
 
-std::string MWV::composeRaw(std::string talkerId,
+std::string MWV::composeRaw(const std::string& talkerId,
                             double windAngle,
                             char reference,
                             double windSpeed,

--- a/src/nmea0183/rmc.cpp
+++ b/src/nmea0183/rmc.cpp
@@ -170,7 +170,7 @@ std::string RMC::getStringContent(bool verbose) const noexcept {
     return ss.str();
 }
 
-std::string RMC::composeRaw(std::string talkerId, unsigned int utcFix, 
+std::string RMC::composeRaw(const std::string& talkerId, unsigned int utcFix, 
                             char status, 
                             double latitude,
                             char latitudeDirection, 

--- a/src/nmea0183/vtg.cpp
+++ b/src/nmea0183/vtg.cpp
@@ -198,7 +198,7 @@ std::string VTG::getStringContent(bool verbose) const noexcept {
     return ss.str();
 }
 
-std::string VTG::composeRaw(std::string talkerId,
+std::string VTG::composeRaw(const std::string& talkerId,
                             double courseOverGroundTrue,
                             double courseOverGroundMagnetic,
                             double speedOverGroundKnots,

--- a/src/nmea0183/zda.cpp
+++ b/src/nmea0183/zda.cpp
@@ -125,7 +125,7 @@ std::string ZDA::getStringContent(bool verbose) const noexcept {
     return ss.str();
 }
 
-std::string ZDA::composeRaw(std::string talkerId,
+std::string ZDA::composeRaw(const std::string& talkerId,
                             double utcTime,
                             unsigned int day,
                             unsigned int month,

--- a/tests/nmea0183/test_GGA.cpp
+++ b/tests/nmea0183/test_GGA.cpp
@@ -25,7 +25,7 @@ TEST(GGA, CreateFromMessage0183Factory)
 
     EXPECT_EQ(ggaMsg->getTalker(), "GN");
     EXPECT_EQ(ggaMsg->getSentenceType(), "GGA");
-    EXPECT_DOUBLE_EQ(ggaMsg->getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(ggaMsg->getUtcTime(), 62735.0);
     EXPECT_NEAR(ggaMsg->getLatitude(), 31.8464692667, 1e-9);
     EXPECT_EQ(ggaMsg->getLatitudeDirection(), 'N');
     EXPECT_NEAR(ggaMsg->getLongitude(), 117.1987063833, 1e-9);
@@ -47,7 +47,7 @@ TEST(GGA, CreateFromMessage0183Factory)
 
     EXPECT_EQ(ggaMsg->getTalker(), "GN");
     EXPECT_EQ(ggaMsg->getSentenceType(), "GGA");
-    EXPECT_DOUBLE_EQ(ggaMsg->getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(ggaMsg->getUtcTime(), 62735.0);
     EXPECT_NEAR(ggaMsg->getLatitude(), 31.8464692667, 1e-9);
     EXPECT_EQ(ggaMsg->getLatitudeDirection(), 'N');
     EXPECT_NEAR(ggaMsg->getLongitude(), 117.1987063833, 1e-9);
@@ -60,7 +60,7 @@ TEST(GGA, CreateFromFields)
 
     EXPECT_EQ(gga.getTalker(), "GN");
     EXPECT_EQ(gga.getSentenceType(), "GGA");
-    EXPECT_DOUBLE_EQ(gga.getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(gga.getUtcTime(), 62735.0);
     EXPECT_NEAR(gga.getLatitude(), 31.8464692667, 1e-9);
     EXPECT_EQ(gga.getLatitudeDirection(), 'N');
     EXPECT_NEAR(gga.getLongitude(), 117.1987063833, 1e-9);
@@ -85,7 +85,7 @@ TEST(GGA, SerializeRoundTripFromFields)
     auto parsed = dynamic_cast<GGA*>(parsedBase.get());
     ASSERT_NE(parsed, nullptr);
 
-    EXPECT_DOUBLE_EQ(parsed->getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(parsed->getUtcTime(), 62735.0);
     EXPECT_NEAR(parsed->getLatitude(), 31.8464692667, 1e-6);
     EXPECT_EQ(parsed->getLatitudeDirection(), 'N');
     EXPECT_NEAR(parsed->getLongitude(), 117.1987063833, 1e-6);
@@ -106,7 +106,7 @@ TEST(GGA, CreateFromMessageFactoryWithIncompleteFieldsDefaults)
     auto ggaMsg = dynamic_cast<GGA*>(msg.get());
     ASSERT_NE(ggaMsg, nullptr);
 
-    EXPECT_DOUBLE_EQ(ggaMsg->getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(ggaMsg->getUtcTime(), 62735.0);
     EXPECT_DOUBLE_EQ(ggaMsg->getLatitude(), 0.0);
     EXPECT_EQ(ggaMsg->getLatitudeDirection(), 'N');
     EXPECT_NEAR(ggaMsg->getLongitude(), 117.1987063833, 1e-9);

--- a/tests/nmea0183/test_GLL.cpp
+++ b/tests/nmea0183/test_GLL.cpp
@@ -29,7 +29,7 @@ TEST(GLL, CreateFromMessage0183Factory)
     EXPECT_EQ(gllMsg->getLatitudeDirection(), 'N');
     EXPECT_NEAR(gllMsg->getLongitude(), 117.1987063833, 1e-9);
     EXPECT_EQ(gllMsg->getLongitudeDirection(), 'E');
-    EXPECT_DOUBLE_EQ(gllMsg->getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(gllMsg->getUtcTime(), 62735.0);
     EXPECT_EQ(gllMsg->getStatus(), 'A');
     EXPECT_EQ(gllMsg->getModeIndicator(), 'A');
 
@@ -44,7 +44,7 @@ TEST(GLL, CreateFromMessage0183Factory)
     EXPECT_EQ(gllMsg->getLatitudeDirection(), 'N');
     EXPECT_NEAR(gllMsg->getLongitude(), 117.1987063833, 1e-9);
     EXPECT_EQ(gllMsg->getLongitudeDirection(), 'E');
-    EXPECT_DOUBLE_EQ(gllMsg->getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(gllMsg->getUtcTime(), 62735.0);
     EXPECT_EQ(gllMsg->getStatus(), 'A');
     EXPECT_EQ(gllMsg->getModeIndicator(), 'A');
 }
@@ -59,7 +59,7 @@ TEST(GLL, CreateFromFields)
     EXPECT_EQ(gll.getLatitudeDirection(), 'N');
     EXPECT_NEAR(gll.getLongitude(), 117.1987063833, 1e-9);
     EXPECT_EQ(gll.getLongitudeDirection(), 'E');
-    EXPECT_DOUBLE_EQ(gll.getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(gll.getUtcTime(), 62735.0);
     EXPECT_EQ(gll.getStatus(), 'A');
     EXPECT_EQ(gll.getModeIndicator(), 'A');
 }
@@ -77,7 +77,7 @@ TEST(GLL, SerializeRoundTripFromFields)
     EXPECT_EQ(parsed->getLatitudeDirection(), 'N');
     EXPECT_NEAR(parsed->getLongitude(), 117.1987063833, 1e-6);
     EXPECT_EQ(parsed->getLongitudeDirection(), 'E');
-    EXPECT_DOUBLE_EQ(parsed->getTimestamp(), 62735.0);
+    EXPECT_DOUBLE_EQ(parsed->getUtcTime(), 62735.0);
     EXPECT_EQ(parsed->getStatus(), 'A');
     EXPECT_EQ(parsed->getModeIndicator(), 'A');
 
@@ -96,7 +96,7 @@ TEST(GLL, CreateFromMessageFactoryWithIncompleteFieldsDefaults)
     EXPECT_EQ(gllMsg->getLatitudeDirection(), 'N');
     EXPECT_NEAR(gllMsg->getLongitude(), 117.1987063833, 1e-9);
     EXPECT_EQ(gllMsg->getLongitudeDirection(), 'E');
-    EXPECT_DOUBLE_EQ(gllMsg->getTimestamp(), 0.0);
+    EXPECT_DOUBLE_EQ(gllMsg->getUtcTime(), 0.0);
     EXPECT_EQ(gllMsg->getStatus(), 'V');
     EXPECT_EQ(gllMsg->getModeIndicator(), 'N');
 }


### PR DESCRIPTION
This pull request focuses on improving code safety and clarity in the NMEA 0183 message handling library. The main changes include making member variable initialization safer, improving API consistency by using references for string parameters, and clarifying time-related naming. Additionally, the checksum validation logic has been refined for better correctness.

**API Consistency and Safety Improvements**

* Changed most internal member variables in message classes (e.g., `DBT`, `GGA`, `GLL`, `GSA`, `MWV`, `RMC`, `VTG`, `ZDA`) to use in-class default initialization, ensuring safer and more predictable construction. [[1]](diffhunk://#diff-364d7b74a868459952cdcba5b22a9cc114a57b266ca745b2ec4b96d4fe3298b5L46-R51) [[2]](diffhunk://#diff-6aa4dd5131375e44f30d7acd7c132e1dc23c4fa9142756ed12f6bc40e6b94954L69-R82) [[3]](diffhunk://#diff-d9813e55eb05f0f8d950ed1ae342323fa77c5cc947004f04d6abfa4deb95e675L54-R60) [[4]](diffhunk://#diff-37d99977b73ed51372529748cb018b748fc411a68ee1439f8de17a3ba6110b5dL53-R59) [[5]](diffhunk://#diff-0b6e389344b170c576c1c573cc70f297e304b36d919f722a9425caae18e47008L44-R48) [[6]](diffhunk://#diff-da45680f56373cfc7c7f162333b67e5a14dcd27fbb78f0f11884bf6959c8773eL85-R97) [[7]](diffhunk://#diff-d97f3b2ba2d5abec223ec11510dc47c3c4fadeee0c52b977365053bf441dbba9L53-R62) [[8]](diffhunk://#diff-6b0e73c91af12906c210afd836bfd6dfb3ba9505a78e930c60cace95d4a015bcL46-R51)
* Updated many `composeRaw` and `create` static functions to take `const std::string&` parameters instead of `std::string`, reducing unnecessary copies and improving performance. [[1]](diffhunk://#diff-01d894e0cb06d4a3f0014df72414da03ff7b1925e5b8b04bd7b8b170cf0339f9L248-R248) [[2]](diffhunk://#diff-364d7b74a868459952cdcba5b22a9cc114a57b266ca745b2ec4b96d4fe3298b5L65-R65) [[3]](diffhunk://#diff-6aa4dd5131375e44f30d7acd7c132e1dc23c4fa9142756ed12f6bc40e6b94954L106-R106) [[4]](diffhunk://#diff-6aa4dd5131375e44f30d7acd7c132e1dc23c4fa9142756ed12f6bc40e6b94954L120-R120) [[5]](diffhunk://#diff-d9813e55eb05f0f8d950ed1ae342323fa77c5cc947004f04d6abfa4deb95e675L77-R77) [[6]](diffhunk://#diff-37d99977b73ed51372529748cb018b748fc411a68ee1439f8de17a3ba6110b5dL74-R74) [[7]](diffhunk://#diff-0b6e389344b170c576c1c573cc70f297e304b36d919f722a9425caae18e47008L61-R61) [[8]](diffhunk://#diff-da45680f56373cfc7c7f162333b67e5a14dcd27fbb78f0f11884bf6959c8773eL120-R120) [[9]](diffhunk://#diff-d97f3b2ba2d5abec223ec11510dc47c3c4fadeee0c52b977365053bf441dbba9L80-R80) [[10]](diffhunk://#diff-6b0e73c91af12906c210afd836bfd6dfb3ba9505a78e930c60cace95d4a015bcL65-R65) [[11]](diffhunk://#diff-85561d0ffef00b0c9fdeb52f6a1d03568191593d0b3ef7bbd909c3e221dc352eL44-R44) [[12]](diffhunk://#diff-807aa579c69305147e51ddd338393c4afeff79696129a51c27d80b11d79ad88eL126-R126) [[13]](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL208-R208) [[14]](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL222-R222)

**Time Field Naming and Usage**

* Renamed time-related member variables and getters in `GGA` and `GLL` from `timestamp_`/`getTimestamp()` to `utcTime_`/`getUtcTime()` for clarity and consistency with NMEA standards. [[1]](diffhunk://#diff-6aa4dd5131375e44f30d7acd7c132e1dc23c4fa9142756ed12f6bc40e6b94954L47-R47) [[2]](diffhunk://#diff-d9813e55eb05f0f8d950ed1ae342323fa77c5cc947004f04d6abfa4deb95e675L44-R44) [[3]](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL93-R93) [[4]](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL138-R138) [[5]](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL178-R178) [[6]](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL194-R194)

**Checksum Validation Logic**

* Updated `Message0183::validate()` to be `noexcept` and improved logic to correctly handle sentences without checksums, returning true if no checksum is present and only validating if one exists. [[1]](diffhunk://#diff-01d894e0cb06d4a3f0014df72414da03ff7b1925e5b8b04bd7b8b170cf0339f9L218-R218) [[2]](diffhunk://#diff-85561d0ffef00b0c9fdeb52f6a1d03568191593d0b3ef7bbd909c3e221dc352eL150-R160)

These changes collectively improve the robustness, performance, and clarity of the NMEA 0183 parsing and composing APIs.