### PR TITLE
[UPDATE] Adjust permissions in CI workflows to enhance security

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,18 +7,21 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   static-analysis:
+    permissions:
+      contents: read
     uses: ./.github/workflows/StaticAnalysis.yml
 
   handle-static-analysis-failure:
     runs-on: ubuntu-latest
     needs: static-analysis
     if: ${{ always() && github.event_name == 'pull_request' && needs.static-analysis.outputs.cppcheck_exit_code != '0' }}
+    permissions:
+      issues: write
+      contents: read
     steps:
     - name: Post or update static analysis comment
       uses: actions/github-script@v7
@@ -82,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: static-analysis
     if: ${{ always() }}
+    permissions:
+      contents: read
     steps:
     - name: Fail workflow when static analysis fails
       run: |
@@ -92,12 +97,17 @@ jobs:
 
   test:
     needs: static-analysis-gate
+    permissions:
+      contents: read
     uses: ./.github/workflows/Test.yml
 
   handle-release-test-failure:
     runs-on: ubuntu-latest
     needs: test
     if: ${{ always() && needs.test.result == 'failure' && (startsWith(github.ref_name, 'release/') || startsWith(github.head_ref, 'release/')) }}
+    permissions:
+      issues: write
+      contents: read
     steps:
     - name: Open issue for failed release test
       uses: actions/github-script@v7
@@ -136,6 +146,8 @@ jobs:
   release:
     needs: test
     if: ${{ needs.test.result == 'success' && (startsWith(github.ref_name, 'release/') || startsWith(github.head_ref, 'release/')) }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/Release.yml
     with:
       branch: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,6 +23,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -104,6 +107,8 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     needs: prepare
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
       if: ${{ github.event_name == 'workflow_dispatch' || inputs.publish }}

--- a/.github/workflows/StaticAnalysis.yml
+++ b/.github/workflows/StaticAnalysis.yml
@@ -13,6 +13,9 @@ on:
         description: "Absolute path of the generated cppcheck XML report"
         value: ${{ jobs.static-analysis.outputs.report_file }}
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -3,6 +3,9 @@ name: Run Tests
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates GitHub Actions workflow files to explicitly set the minimum required permissions for each job, improving security by following the principle of least privilege. The main focus is on restricting permissions to only what is necessary for each workflow and job.

**Workflow permissions tightening:**

* Updated `.github/workflows/CI.yml` to set global and per-job permissions, reducing default permissions from `write` to `read` where possible, and only granting `write` access to jobs that require it (e.g., release jobs). [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L10-R24) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R88-R89) [[3]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R100-R110) [[4]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R149-R150)
* Updated `.github/workflows/Release.yml` to add a global `contents: read` permission and specify job-level permissions for the `build-linux` job. [[1]](diffhunk://#diff-0018b3428cb849f2f65d08b298005ce9167597b30de9ba5d6f5d825deb0daabaR26-R28) [[2]](diffhunk://#diff-0018b3428cb849f2f65d08b298005ce9167597b30de9ba5d6f5d825deb0daabaR110-R111)
* Updated `.github/workflows/StaticAnalysis.yml` to set a global `contents: read` permission.
* Updated `.github/workflows/Test.yml` to set a global `contents: read` permission.

These changes help ensure that each workflow and job only has the permissions it needs, reducing the risk of accidental or malicious changes.