### PR TITLE
[FIX] Enhance library packaging and installation process

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -155,29 +155,54 @@ jobs:
     - name: Build release (library + cli)
       run: cmake --build ${{ steps.strings.outputs.build-cli-dir }} --config Release
 
-    - name: Package library release
+    - name: Prepare library package
       working-directory: ${{ steps.strings.outputs.build-lib-dir }}
       run: |
-        cmake --install . --prefix nmealib
-        tar -czf nmealib-linux64.tar.gz nmealib/
+        # Install library to dist directory
+        cmake --install . --prefix dist --component library
+        
+        # Create versioned package directory with proper structure
+        mkdir -p nmealib-${{ needs.prepare.outputs.version }}/{lib/cmake/nmealib,include}
+        
+        # Copy library files
+        cp -r dist/lib/libnmealib.a nmealib-${{ needs.prepare.outputs.version }}/lib/
+        
+        # Copy headers
+        cp -r dist/include/* nmealib-${{ needs.prepare.outputs.version }}/include/
+        
+        # Copy cmake config file
+        cp dist/lib/cmake/nmealib/nmealibConfig.cmake nmealib-${{ needs.prepare.outputs.version }}/lib/cmake/nmealib/
+        
+        # Copy documentation and license
+        cp ${{ github.workspace }}/README.md nmealib-${{ needs.prepare.outputs.version }}/
+        cp ${{ github.workspace }}/LICENSE nmealib-${{ needs.prepare.outputs.version }}/
+        
+        # Create tarball
+        tar -czf nmealib-${{ needs.prepare.outputs.version }}-linux64.tar.gz nmealib-${{ needs.prepare.outputs.version }}/
 
     - name: Package cli release
       working-directory: ${{ steps.strings.outputs.build-cli-dir }}
       run: |
-        cmake --install . --prefix nmealib-cli
-        tar -czf nmealib-cli-linux64.tar.gz nmealib-cli/
+        cmake --install . --prefix nmealib-cli-dist
+        mkdir -p nmealib-cli-${{ needs.prepare.outputs.version }}
+        cp -r nmealib-cli-dist/lib nmealib-cli-${{ needs.prepare.outputs.version }}/
+        cp -r nmealib-cli-dist/include nmealib-cli-${{ needs.prepare.outputs.version }}/
+        cp -r nmealib-cli-dist/bin nmealib-cli-${{ needs.prepare.outputs.version }}/
+        cp ${{ github.workspace }}/README.md nmealib-cli-${{ needs.prepare.outputs.version }}/
+        cp ${{ github.workspace }}/LICENSE nmealib-cli-${{ needs.prepare.outputs.version }}/
+        tar -czf nmealib-cli-${{ needs.prepare.outputs.version }}-linux64.tar.gz nmealib-cli-${{ needs.prepare.outputs.version }}/
 
     - name: Upload library artifact
       uses: actions/upload-artifact@v4
       with:
         name: nmealib-linux64
-        path: ${{ steps.strings.outputs.build-lib-dir }}/nmealib-linux64.tar.gz
+        path: ${{ steps.strings.outputs.build-lib-dir }}/nmealib-${{ needs.prepare.outputs.version }}-linux64.tar.gz
 
     - name: Upload cli artifact
       uses: actions/upload-artifact@v4
       with:
         name: nmealib-cli-linux64
-        path: ${{ steps.strings.outputs.build-cli-dir }}/nmealib-cli-linux64.tar.gz
+        path: ${{ steps.strings.outputs.build-cli-dir }}/nmealib-cli-${{ needs.prepare.outputs.version }}-linux64.tar.gz
 
   publish:
     runs-on: ubuntu-latest
@@ -197,5 +222,4 @@ jobs:
         name: ${{ needs.prepare.outputs.tag }}
         generate_release_notes: true
         files: |
-          dist/**/nmealib-linux64.tar.gz
-          dist/**/nmealib-cli-linux64.tar.gz
+          dist/**/*-linux64.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,18 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
     COMPONENT library
 )
 
+# Install CMake config file for find_package(nmealib) support
+install(FILES ${PROJECT_SOURCE_DIR}/scripts/nmealibConfig.cmake
+    DESTINATION lib/cmake/nmealib
+    COMPONENT library
+)
+
+# Install license and readme
+install(FILES ${PROJECT_SOURCE_DIR}/LICENSE ${PROJECT_SOURCE_DIR}/README.md
+    DESTINATION .
+    COMPONENT library
+)
+
 if(BUILD_CLI)
     # Install cli application
     install(TARGETS nmealib-cli

--- a/scripts/nmealibConfig.cmake
+++ b/scripts/nmealibConfig.cmake
@@ -1,0 +1,47 @@
+# nmealibConfig.cmake
+# Provides find_package(nmealib) support for CMake projects
+#
+# Usage:
+#   find_package(nmealib REQUIRED)
+#   target_link_libraries(your_app PRIVATE nmealib::nmealib)
+# 
+# Or with explicit PATH:
+#   find_package(nmealib REQUIRED PATHS /path/to/nmealib-1.0.0/lib/cmake/nmealib)
+
+# Determine package directory
+# Config file is at: <prefix>/lib/cmake/nmealib/nmealibConfig.cmake
+# So: CMAKE_CURRENT_LIST_DIR/../.. = <prefix>/lib
+# Therefore: CMAKE_CURRENT_LIST_DIR/../../.. = <prefix>
+get_filename_component(NMEALIB_PACKAGE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+# Locate library
+find_library(NMEALIB_LIBRARY
+    NAMES nmealib
+    PATHS "${NMEALIB_PACKAGE_DIR}/lib"
+    NO_DEFAULT_PATH
+    REQUIRED
+)
+
+# Include directory
+set(NMEALIB_INCLUDE_DIR "${NMEALIB_PACKAGE_DIR}/include")
+
+if(NOT EXISTS "${NMEALIB_INCLUDE_DIR}")
+    message(FATAL_ERROR "nmealib include directory not found: ${NMEALIB_INCLUDE_DIR}")
+endif()
+
+# Create imported target
+if(NOT TARGET nmealib::nmealib)
+    add_library(nmealib::nmealib STATIC IMPORTED)
+    set_target_properties(nmealib::nmealib PROPERTIES
+        IMPORTED_LOCATION "${NMEALIB_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${NMEALIB_INCLUDE_DIR}"
+    )
+endif()
+
+# For backwards compatibility, also provide nmealib target
+if(NOT TARGET nmealib)
+    add_library(nmealib INTERFACE IMPORTED)
+    target_link_libraries(nmealib INTERFACE nmealib::nmealib)
+endif()
+
+message(STATUS "Found nmealib: ${NMEALIB_LIBRARY}")

--- a/src/nmea0183/CMakeLists.txt
+++ b/src/nmea0183/CMakeLists.txt
@@ -60,19 +60,3 @@ set(NMEALIB_NMEA0183_SOURCES
     nmea0183/zda.cpp
     PARENT_SCOPE
 )
-
-install(TARGETS
-    nmealib0183
-    nmealib0183_dbt
-    nmealib0183_gga
-    nmealib0183_gll
-    nmealib0183_gsa
-    nmealib0183_mwv
-    nmealib0183_rmc
-    nmealib0183_vhw
-    nmealib0183_vtg
-    nmealib0183_zda
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    COMPONENT library
-)

--- a/src/nmea2000/CMakeLists.txt
+++ b/src/nmea2000/CMakeLists.txt
@@ -14,10 +14,3 @@ set(NMEALIB_NMEA2000_SOURCES
     nmea2000/nmea2000Factory.cpp
     PARENT_SCOPE
 )
-
-install(TARGETS
-    nmealib2000
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    COMPONENT library
-)


### PR DESCRIPTION
This pull request refactors the packaging and installation process for the `nmealib` library and CLI, with a focus on improving CMake integration and package structure. The changes ensure that consumers of the library can easily use `find_package(nmealib)` in their CMake projects, and that distributed tarballs have a consistent, versioned layout with all necessary files included.

Packaging and distribution improvements:

* The packaging steps in `.github/workflows/Release.yml` now create versioned tarballs for both the library and CLI, including headers, CMake config, documentation, and license files in a standardized directory structure.
* The release workflow artifact upload and release asset matching patterns have been updated to handle the new versioned tarball names.

CMake integration enhancements:

* A new `nmealibConfig.cmake` file is provided and installed, enabling downstream projects to use `find_package(nmealib)` for easy integration. [[1]](diffhunk://#diff-00da67b788b138defd0e1d48fc0c8e55c5da59549c723000a4cce0f061299322R1-R47) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR26-R37)
* The main `CMakeLists.txt` now installs the CMake config file, license, and README as part of the library installation process.

Cleanup of legacy installation logic:

* Old installation commands for individual NMEA0183 and NMEA2000 component targets have been removed from their respective `CMakeLists.txt` files, simplifying the build and install process. [[1]](diffhunk://#diff-412001cf6a62ad99ec41c390cf9d1789f66d595cc8e47f5d33a1798eeeee7e5aL63-L78) [[2]](diffhunk://#diff-21b9ba0288f31e9403a0319c5f8e0614fb2b984156d6feff61dac93d46f23fcfL17-L23)