### PR TITLE
[FIX] Fixed variable sentencies length

### DIFF
--- a/src/nmea0183/gga.cpp
+++ b/src/nmea0183/gga.cpp
@@ -33,9 +33,9 @@ std::unique_ptr<GGA> GGA::create(std::unique_ptr<Message0183> baseMessage) {
     if (!fields.empty()) {
         fields.erase(fields.begin());
     }
-
-    if (fields.size() != 14) {
-        throw NotGGAException(context, "Insufficient fields in GGA payload: expected 14, got " + std::to_string(fields.size()) + ". Payload: " + payload);
+    size_t messageSize = fields.size();
+    if (messageSize != 14 && messageSize != 12) {
+        throw NotGGAException(context, "Insufficient fields in GGA payload: expected 14 or 12, got " + std::to_string(fields.size()) + ". Payload: " + payload);
     }
 
     try {
@@ -51,8 +51,13 @@ std::unique_ptr<GGA> GGA::create(std::unique_ptr<Message0183> baseMessage) {
         char altitudeUnits = fields[9].empty() ? '\0' : fields[9][0];
         double geoidalSeparation = fields[10].empty() ? 0.0 : std::stod(fields[10]);
         char geoidalSeparationUnits = fields[11].empty() ? '\0' : fields[11][0];
-        double dgpsAge = fields[12].empty() ? 0.0 : std::stod(fields[12]);
-        std::string dgpsReferenceStationId = fields[13].empty() ? "" : fields[13];
+        double dgpsAge = -1;
+        std::string dgpsReferenceStationId = "";
+
+        if(messageSize == 14) {
+            dgpsAge = fields[12].empty() ? 0.0 : std::stod(fields[12]);
+            dgpsReferenceStationId = fields[13].empty() ? "" : fields[13];
+        }
 
         return std::unique_ptr<GGA>(new GGA(std::move(*baseMessage),
                                             timestamp,

--- a/src/nmea0183/rmc.cpp
+++ b/src/nmea0183/rmc.cpp
@@ -30,8 +30,9 @@ std::unique_ptr<RMC> RMC::create(std::unique_ptr<Message0183> baseMessage) {
         fields.erase(fields.begin());
     }
 
-    if (fields.size() != 13) {
-        throw NotRMCException(context, "Insufficient fields in RMC payload: expected 13, got " + std::to_string(fields.size()) + ". Payload: " + payload);
+    size_t messageSize = fields.size();
+    if (messageSize != 12 && messageSize != 13) {
+        throw NotRMCException(context, "Insufficient fields in RMC payload: expected 12 or 13, got " + std::to_string(fields.size()) + ". Payload: " + payload);
     }
 
     try {
@@ -46,8 +47,15 @@ std::unique_ptr<RMC> RMC::create(std::unique_ptr<Message0183> baseMessage) {
         unsigned int date = fields[8].empty() ? 0 : std::stoul(fields[8]);
         double magneticVariation = fields[9].empty() ? 0.0 : std::stod(fields[9]);
         char magneticVariationDirection = fields[10].empty() ? '\0' : fields[10][0];
-        char modeIndicator = fields[11].empty() ? '\0' : fields[11][0];
-        char navigationStatus = fields[12].empty() ? '\0' : fields[12][0];
+        char modeIndicator = '\0';
+        char navigationStatus = '\0';
+
+        if (messageSize == 12) {
+            navigationStatus = fields[11].empty() ? '\0' : fields[11][0];
+        } else if (messageSize == 13) {
+            modeIndicator = fields[11].empty() ? '\0' : fields[11][0];
+            navigationStatus = fields[12].empty() ? '\0' : fields[12][0];
+        }
 
         return std::unique_ptr<RMC>(new RMC(std::move(*baseMessage), utcFix, status, latitude, latDirection, longitude, lonDirection, speedOverGround, courseOverGround, date, magneticVariation, magneticVariationDirection, modeIndicator, navigationStatus));
     } catch (const std::exception& e) {


### PR DESCRIPTION
This pull request updates the parsing logic for NMEA0183 GGA and RMC messages to handle both standard and truncated message formats. The changes ensure that messages with missing optional fields are accepted and parsed safely, improving compatibility with real-world data.

**Parsing logic improvements for optional fields:**

* [`src/nmea0183/gga.cpp`](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL36-R38): Updated the GGA message parser to accept both 14-field (extended) and 12-field (standard) messages. The code now conditionally parses the optional DGPS fields only if present, and sets default values otherwise. [[1]](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL36-R38) [[2]](diffhunk://#diff-a5abaacb4c90fdc4e3ac446d51389886621bf28b6e13fa99adfd55f70a249ceaL54-R60)
* [`src/nmea0183/rmc.cpp`](diffhunk://#diff-5c80ad5ec3a4cb9f27287f7db7b79a0ce0674e973b9812ec8c1870955f53b7c8L33-R35): Updated the RMC message parser to accept both 13-field (extended) and 12-field (standard) messages. The code now conditionally parses the optional mode indicator and navigation status fields, assigning default values if they are missing. [[1]](diffhunk://#diff-5c80ad5ec3a4cb9f27287f7db7b79a0ce0674e973b9812ec8c1870955f53b7c8L33-R35) [[2]](diffhunk://#diff-5c80ad5ec3a4cb9f27287f7db7b79a0ce0674e973b9812ec8c1870955f53b7c8L49-R58)